### PR TITLE
Update category.js

### DIFF
--- a/app/javascript/item/category.js
+++ b/app/javascript/item/category.js
@@ -1,4 +1,4 @@
-window.addEventListener('load', function () {
+window.addEventListener('turbolinks:load', function () {
 // 子レベルのselectタグ
 function add_childSelect_tag() {
   let child_select_form = `


### PR DESCRIPTION
# Why
商品出品ページでカテゴリを選択する際、リロードしないと選択できない問題が発生した。
それを解決するためにこのブランチを作成した。

# What
jsファイルの1行目にある ’load’ を ’turbolinks:load’ に変更した。